### PR TITLE
Add Jersey Client Configuration capability to the JUnit Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ If the ExtensionContext is required to configure the application, you can instea
         return new ResourceConfig(DummyResource.class);
     }
  ```
+
+If the client configuration needs to be customized, then you can also pass in a function that accepts an ClientConfig and returns a modified ClientConfig object.
+
+ ```java
+    @RegisterExtension
+    JerseyExtension jerseyExtension = new JerseyExtension(this::configureJersey, this::configureJerseyClient);
+
+    private Application configureJersey(ExtensionContext extensionContext) {
+        return new ResourceConfig(DummyResource.class);
+    }
+    
+    private ClientConfig configureJerseyClient(ExtensionContext extensionContext, ClientConfig clientConfig) {
+		clientConfig.connectorProvider(new ApacheConnectorProvider());
+		return clientConfig;
+	}
+	
+    
+ ```
+
  
  You can then [inject](https://junit.org/junit5/docs/current/user-guide/#writing-tests-dependency-injection) the WebTarget, Client or base URI as test method or constructor parameters.
  

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     testRuntime("org.apache.logging.log4j:log4j-core:${log4jVersion}")
     testRuntime("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 
-    testCompile group: 'com.google.truth', name: 'truth', version: '0.36'
     testRuntime("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}")
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitJupiterVersion
 }

--- a/src/main/java/com/github/hanleyt/JerseyExtension.java
+++ b/src/main/java/com/github/hanleyt/JerseyExtension.java
@@ -34,6 +34,11 @@ public class JerseyExtension implements BeforeEachCallback, AfterEachCallback, P
         this.configProvider = null;
     }
 
+    public JerseyExtension(Supplier<Application> applicationSupplier, BiFunction<ExtensionContext, ClientConfig, ClientConfig> configProvider) {
+        this.applicationProvider = (unused) -> applicationSupplier.get();
+        this.configProvider = configProvider;
+    }
+
     public JerseyExtension(Function<ExtensionContext, Application> applicationProvider) {
         this.applicationProvider = applicationProvider;
         this.configProvider = null;

--- a/src/main/java/com/github/hanleyt/JerseyExtension.java
+++ b/src/main/java/com/github/hanleyt/JerseyExtension.java
@@ -1,5 +1,6 @@
 package com.github.hanleyt;
 
+import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -13,6 +14,7 @@ import javax.ws.rs.core.Application;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -21,6 +23,7 @@ public class JerseyExtension implements BeforeEachCallback, AfterEachCallback, P
     private static final Collection<Class<?>> INJECTABLE_PARAMETER_TYPES = Arrays.asList(Client.class, WebTarget.class, URI.class);
 
     private final Function<ExtensionContext, Application> applicationProvider;
+    private final BiFunction<ExtensionContext, ClientConfig, ClientConfig> configProvider;
 
     private JerseyExtension() {
         throw new IllegalStateException("JerseyExtension must be registered programmatically");
@@ -28,10 +31,17 @@ public class JerseyExtension implements BeforeEachCallback, AfterEachCallback, P
 
     public JerseyExtension(Supplier<Application> applicationSupplier) {
         this.applicationProvider = (unused) -> applicationSupplier.get();
+        this.configProvider = null;
     }
 
     public JerseyExtension(Function<ExtensionContext, Application> applicationProvider) {
         this.applicationProvider = applicationProvider;
+        this.configProvider = null;
+    }
+
+    public JerseyExtension(Function<ExtensionContext, Application> applicationProvider, BiFunction<ExtensionContext, ClientConfig, ClientConfig> configProvider) {
+        this.applicationProvider = applicationProvider;
+        this.configProvider = configProvider;
     }
 
     @Override
@@ -48,6 +58,14 @@ public class JerseyExtension implements BeforeEachCallback, AfterEachCallback, P
                 getStore(context).put(URI.class, getBaseUri());
                 return applicationProvider.apply(context);
             }
+
+			@Override
+			protected void configureClient(ClientConfig config) {
+				if (configProvider != null) {
+					config = configProvider.apply(context, config);
+				}
+				super.configureClient(config);
+			}
         };
         jerseyTest.setUp();
         getStore(context).put(JerseyTest.class, jerseyTest);

--- a/src/main/java/com/github/hanleyt/JerseyExtension.java
+++ b/src/main/java/com/github/hanleyt/JerseyExtension.java
@@ -64,13 +64,13 @@ public class JerseyExtension implements BeforeEachCallback, AfterEachCallback, P
                 return applicationProvider.apply(context);
             }
 
-			@Override
-			protected void configureClient(ClientConfig config) {
-				if (configProvider != null) {
-					config = configProvider.apply(context, config);
-				}
-				super.configureClient(config);
-			}
+            @Override
+            protected void configureClient(ClientConfig config) {
+                if (configProvider != null) {
+                    config = configProvider.apply(context, config);
+                }
+                super.configureClient(config);
+            }
         };
         jerseyTest.setUp();
         getStore(context).put(JerseyTest.class, jerseyTest);

--- a/src/test/java/com/github/hanleyt/JerseyExtensionTest.java
+++ b/src/test/java/com/github/hanleyt/JerseyExtensionTest.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.net.URI;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("JerseyExtension should")
 class JerseyExtensionTest {
@@ -31,11 +31,11 @@ class JerseyExtensionTest {
     @DisplayName("only be registered programmatically")
     void only_be_registered_programmatically() throws NoSuchMethodException {
         Constructor<JerseyExtension> constructor = JerseyExtension.class.getDeclaredConstructor();
-        assertThat(Modifier.isPrivate(constructor.getModifiers())).isTrue();
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         Exception exception = Assertions.assertThrows(Exception.class, constructor::newInstance);
-        assertThat(exception).hasCauseThat().isInstanceOf(IllegalStateException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("JerseyExtension must be registered programmatically");
+        assertTrue(exception.getCause() instanceof IllegalStateException);
+        assertTrue(exception.getCause().getMessage().contains("JerseyExtension must be registered programmatically"));
     }
 
     @Nested
@@ -52,17 +52,17 @@ class JerseyExtensionTest {
         @Test
         @DisplayName("access the resource using the injected WebTarget")
         void web_target_is_injected(WebTarget target) {
-            assertThat(target).isNotNull();
+            assertNotNull(target);
             String values = target.path("values").request().get(String.class);
-            assertThat(values).isEqualTo(DummyResource.DEFAULT_VALUES);
+            assertEquals(DummyResource.DEFAULT_VALUES, values);
         }
 
         @Test
         @DisplayName("access the resource using the injected Client and URI")
         void client_is_injected(Client client, URI baseUri) {
-            assertThat(client).isNotNull();
+            assertNotNull(client);
             String values = client.target(baseUri).path("values").request().get(String.class);
-            assertThat(values).isEqualTo(DummyResource.DEFAULT_VALUES);
+            assertEquals(DummyResource.DEFAULT_VALUES, values);
         }
 
     }
@@ -76,9 +76,9 @@ class JerseyExtensionTest {
         JerseyExtension jerseyExtension = new JerseyExtension(this::configureJersey);
 
         private ResourceConfig configureJersey(ExtensionContext extensionContext) {
-            assertThat(extensionContext).isNotNull();
+            assertNotNull(extensionContext);
             String testValue = ExtensionNeededToConfigureJersey.getStore(extensionContext).get(String.class, String.class);
-            assertThat(testValue).isNotEmpty();
+            assertFalse(testValue.isEmpty());
             ResourceConfig resourceConfig = new ResourceConfig();
             resourceConfig.register(new DummyResource(testValue));
             return resourceConfig;
@@ -87,17 +87,17 @@ class JerseyExtensionTest {
         @Test
         @DisplayName("access the resource using the injected WebTarget")
         void web_target_is_injected(WebTarget target) {
-            assertThat(target).isNotNull();
+            assertNotNull(target);
             String values = target.path("values").request().get(String.class);
-            assertThat(values).isEqualTo(ExtensionNeededToConfigureJersey.TEST_VALUE);
+            assertEquals(ExtensionNeededToConfigureJersey.TEST_VALUE, values);
         }
 
         @Test
         @DisplayName("access the resource using the injected Client and URI")
         void client_is_injected(Client client, URI baseUri) {
-            assertThat(client).isNotNull();
+            assertNotNull(client);
             String values = client.target(baseUri).path("values").request().get(String.class);
-            assertThat(values).isEqualTo(ExtensionNeededToConfigureJersey.TEST_VALUE);
+            assertEquals(ExtensionNeededToConfigureJersey.TEST_VALUE, values);
         }
     }
 
@@ -139,37 +139,37 @@ class JerseyExtensionTest {
         @DisplayName("create the JerseyTest and add it to the store")
         void jersey_test_is_added_to_the_store() {
             JerseyTest jerseyTest = JerseyExtension.getStore(extensionContext).get(JerseyTest.class, JerseyTest.class);
-            assertThat(jerseyTest).isNotNull();
+            assertNotNull(jerseyTest);
         }
 
         @Test
         @DisplayName("create the Client and add it to the store")
         void client_is_added_to_the_store() {
             Client client = JerseyExtension.getStore(extensionContext).get(Client.class, Client.class);
-            assertThat(client).isNotNull();
+            assertNotNull(client);
 
             JerseyTest jerseyTest = JerseyExtension.getStore(extensionContext).get(JerseyTest.class, JerseyTest.class);
-            assertThat(client).isSameAs(jerseyTest.client());
+            assertTrue(client == jerseyTest.client());
         }
 
         @Test
         @DisplayName("create the WebTarget and add it to the store")
         void web_target_is_added_to_the_store() {
             WebTarget webTarget = JerseyExtension.getStore(extensionContext).get(WebTarget.class, WebTarget.class);
-            assertThat(webTarget).isNotNull();
+            assertNotNull(webTarget);
 
             JerseyTest jerseyTest = JerseyExtension.getStore(extensionContext).get(JerseyTest.class, JerseyTest.class);
-            assertThat(webTarget.getUri()).isEqualTo(jerseyTest.target().getUri());
+            assertEquals(webTarget.getUri(), jerseyTest.target().getUri());
         }
 
         @Test
         @DisplayName("create the URI and add it to the store")
         void uri_is_added_to_the_store() {
             URI baseUri = JerseyExtension.getStore(extensionContext).get(URI.class, URI.class);
-            assertThat(baseUri).isNotNull();
+            assertNotNull(baseUri);
 
             WebTarget webTarget = JerseyExtension.getStore(extensionContext).get(WebTarget.class, WebTarget.class);
-            assertThat(baseUri).isEqualTo(webTarget.getUri());
+            assertEquals(baseUri, webTarget.getUri());
         }
 
         @Nested
@@ -186,28 +186,28 @@ class JerseyExtensionTest {
             @DisplayName("the JerseyTest has been removed from the store")
             void jersey_test_is_added_to_the_store() {
                 JerseyTest jerseyTest = JerseyExtension.getStore(extensionContext).get(JerseyTest.class, JerseyTest.class);
-                assertThat(jerseyTest).isNull();
+                assertNull(jerseyTest);
             }
 
             @Test
             @DisplayName("the Client has been removed from the store")
             void client_is_added_to_the_store() {
                 Client client = JerseyExtension.getStore(extensionContext).get(Client.class, Client.class);
-                assertThat(client).isNull();
+                assertNull(client);
             }
 
             @Test
             @DisplayName("the WebTarget has been removed from the store")
             void web_target_is_added_to_the_store() {
                 WebTarget webTarget = JerseyExtension.getStore(extensionContext).get(WebTarget.class, WebTarget.class);
-                assertThat(webTarget).isNull();
+                assertNull(webTarget);
             }
 
             @Test
             @DisplayName("the URI has been removed from the store")
             void uri_is_added_to_the_store() {
                 URI baseUri = JerseyExtension.getStore(extensionContext).get(URI.class, URI.class);
-                assertThat(baseUri).isNull();
+                assertNull(baseUri);
             }
 
         }

--- a/src/test/java/com/github/hanleyt/JerseyExtensionTest.java
+++ b/src/test/java/com/github/hanleyt/JerseyExtensionTest.java
@@ -105,7 +105,7 @@ class JerseyExtensionTest {
     @Nested
     @DisplayName("when registered and configured with a simple resource and a client configuration function.")
     class SimpleResourceWithClientConfigurationApp {
-    	boolean configureClientCalled = false;
+        boolean configureClientCalled = false;
 
         @RegisterExtension
         JerseyExtension jerseyExtension = new JerseyExtension(this::configureJersey, this::configureJerseyClient);
@@ -118,9 +118,9 @@ class JerseyExtensionTest {
             assertNotNull(extensionContext);
             assertNotNull(clientConfig);
             configureClientCalled = true;
-    		return clientConfig;
-    	}
-    	
+            return clientConfig;
+        }
+
         @Test
         @DisplayName("access the resource using the injected WebTarget")
         void web_target_is_injected(WebTarget target) {
@@ -145,8 +145,8 @@ class JerseyExtensionTest {
     @DisplayName("when registered and configured with a resource that depends on another extension and a client configuration function.")
     @ExtendWith(ExtensionNeededToConfigureJersey.class)
     class ResourceWithDependenciesWithClientConfigurationApp {
-    	boolean configureClientCalled = false;
-    	
+        boolean configureClientCalled = false;
+
         @RegisterExtension
         JerseyExtension jerseyExtension = new JerseyExtension(this::configureJersey, this::configureJerseyClient);
 
@@ -163,9 +163,9 @@ class JerseyExtensionTest {
             assertNotNull(extensionContext);
             assertNotNull(clientConfig);
             configureClientCalled = true;
-    		return clientConfig;
-    	}
-    	
+            return clientConfig;
+        }
+
         @Test
         @DisplayName("access the resource using the injected WebTarget")
         void web_target_is_injected(WebTarget target) {


### PR DESCRIPTION
Besides configuring the application, the Jersey test suite also allows for customising the client configuration.  This JUnit 5 extension only allowed for application configuration.  I have added the ability to supply a client configuration as well.

I didn't go overboard with overloading the constructor, so some convenience combinations were not implemented.  If all the shortcuts are required, maybe adding a Builder object might be warranted.

Also, I removed the dependency on com.google.common.truth.Truth and replaced it with generic JUnit5 assertions.  I had trouble with that library (the version I downloaded seemed to depend on GWT).  I hope that's OK.