### PR TITLE
Set container port to zero to allocate available tcp port

### DIFF
--- a/src/main/java/com/github/hanleyt/JerseyExtension.java
+++ b/src/main/java/com/github/hanleyt/JerseyExtension.java
@@ -3,6 +3,7 @@ package com.github.hanleyt;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -69,8 +70,10 @@ public class JerseyExtension implements BeforeEachCallback, AfterEachCallback, P
 
     private JerseyTest initJerseyTest(ExtensionContext context) throws Exception {
         JerseyTest jerseyTest = new JerseyTest() {
+
             @Override
             protected DeploymentContext configureDeployment() {
+                forceSet(TestProperties.CONTAINER_PORT, "0");
                 return deploymentContextProvider.apply(context);
             }
 


### PR DESCRIPTION
We use JerseyExtension in unit tests and sometimes the problem occurs that multiple Jenkins builds run some of these tests in parallel, which leads to test failures because the default port 9998 is not available.

This commit sets the container port to "0" in order to let Jersey allocate any unused port.

I've thought about making this configurable, but so far couldn't come up with a reason why this shouldn't be the default. Any thoughts? 